### PR TITLE
Add missing assemblies

### DIFF
--- a/at.vintagestory.VintageStory.yaml
+++ b/at.vintagestory.VintageStory.yaml
@@ -18,6 +18,7 @@ modules:
     build-commands:
       - /usr/lib/sdk/mono6/install.sh
       - cp /usr/lib/sdk/mono6/lib/mono/4.5/cert-sync.exe /app/lib/mono/4.5/
+      - install /usr/lib/sdk/mono6/lib/mono/4.5/mcs.exe /app/lib/mono/4.5
   - name: libgdiplus
     sources:
       - type: archive
@@ -26,7 +27,7 @@ modules:
   - name: VintageStory
     buildsystem: simple
     build-commands:
-      - install -Dpt /app/bin vintagestory apply_extra
+      - install -Dpt /app/bin vintagestory apply_extra mcs
       - install -Dpt /app/share/icons/hicolor/512x512/apps at.vintagestory.VintageStory.png
       - install -Dpt /app/share/metainfo at.vintagestory.VintageStory.metainfo.xml
       - desktop-file-install --dir=/app/share/applications at.vintagestory.VintageStory.desktop
@@ -38,6 +39,10 @@ modules:
                 # communication with Vintage Story's auth server may fail
           - /app/bin/mono ${MONO_PATH}/cert-sync.exe --quiet --user /etc/ssl/certs/ca-certificates.crt
           - exec /app/bin/mono /app/extra/vintagestory/Vintagestory.exe
+      - type: script
+        dest-filename: mcs
+        commands:
+          - exec /app/bin/mono $MONO_OPTIONS /app/lib/mono/4.5/mcs.exe "$@"
       - type: file
         path: at.vintagestory.VintageStory.desktop
       - type: file

--- a/at.vintagestory.VintageStory.yaml
+++ b/at.vintagestory.VintageStory.yaml
@@ -18,6 +18,7 @@ modules:
     build-commands:
       - /usr/lib/sdk/mono6/install.sh
       - cp /usr/lib/sdk/mono6/lib/mono/4.5/cert-sync.exe /app/lib/mono/4.5/
+      - cp -a /usr/lib/sdk/mono6/lib/mono/4.5/Facades /app/lib/mono/4.5
       - install /usr/lib/sdk/mono6/lib/mono/4.5/mcs.exe /app/lib/mono/4.5
   - name: libgdiplus
     sources:


### PR DESCRIPTION
Fixes #38

# Changes

There are two changes introduced in the build process:

* added `Facades` assemblies (it's similar to the solution in [OpenRA flatpak](https://github.com/flathub/net.openra.OpenRA/blob/074d2f5b04825542c29b127a21d25671ce3035b8/net.openra.OpenRA.yaml#L235-L236))
* added C# compiler `mcs`

into the app.

# Impact

It eliminates most crashes caused by joining to modded multiplayer games.

Without this patch, some mods crash the game due to missing assemblies, especially `netstandard` and others, that are a part of facades.

Other mods cause crashes due to missing C# compiler. This is because VS allows writing source code mods in pure C#, and they are compiled on the fly by the game. This requires the presence of `mcs` assembly.

This also increases compatibility with mods in singleplayer games. Mods that cause the game to crash in multiplayer, in singleplayer they fail silently, the game starts without these mods loaded.

As for the impact in application size, facades are very small in size. Total increase in size because of facades is about 775 kb, and mcs weights around 1.7 mb.

# Tests

I've been able to test the changes with local flatpak build on servers I've had previously problems with.

The following multiplayer v1.18.1 servers were previously always crashing upon joining, but not anymore:

## Middarstead

advancedsmithing@1.3.0, metalrecoverydon@1.0.1, furniturelibrary@1.0.8, medieval@2.01.06, NoMoreDrifterThrowing@1.0.0, ragnamans-lit-torch-recipe@1.0.0, usefuldrifterloot@1.0.2, game@1.18.1, wildcrafttrees@1.1.5, carryon@1.0.0, petai@1.7.0, stillnecessaries@1.0.0, vanvar@3.1.1, creative@1.18.1, survival@1.18.1, woodbarrels@1.0.4, woodchests@1.0.5, workbenchexpansion@1.6.0, wolftaming@1.7.1, roadworks@1.0.9

## {CoB} Conquest of Blocks

acorns@0.5.1, bettercrates@1.6.0, Ceramos@0.3.1, chiseltools@1.8.4, drdecor@1.2.0, extrachests@1.7.0, foundrymod@1.0.0, furniturelibrary@1.0.8, instruments@1.2.0, spyglass@0.4.5, tprunes@1.0.8, thecritterpack@0.7.6, game@1.18.1, carryon@1.0.0, carryonmore@1.5.0, commonlib@2.0.4, sailboat@1.0.0, petai@1.7.0, rifteye@0.1.3, simplestep@1.0.3, creative@1.18.1, vsquest@0.4.1, survival@1.18.1, workbenchexpansion@1.6.1, xlib@0.7.0-pre.3, awearablelight@1.0.4, captureanimals@2.5.0, cob@1.0.8, em@2.0.0-pre.5, playercorpse@1.7.1, wolftaming@1.7.0, xskills@0.7.0-pre.5, bricklayers@2.0.0-pre.4

## Teamwork

meteoricexpansion@1.2.3, game@1.18.1, wildcrafttrees@1.1.5, carryon@1.0.0, creative@1.18.1, survival@1.18.1

## Hell's Gate - [Homepoints] [PvE]

canmarket@0.2.2, chiseltools@1.8.4, composter@1.0.4, FlexibleTools@2.1.0, furniturelibrary@1.0.8, HangingOilLamps@1.0.1, mannequinstand@1.0.1, medieval@2.01.08, meteoricexpansion@1.2.3, nightwatcher@1.4.0, pieontheshelf@1.0.0, qptech@1.13.02, game@1.18.1, alchemy@1.6.9, animalcages@2.1.4, carryon@1.0.0, commonlib@2.0.4, lc@1.0.0, medievalexpansion@3.9.1, morepiles@1.3.0, petai@1.7.0, usefulstuff17@1.1.3, vanvar@3.1.1, creative@1.18.1, survival@1.18.1, workbenchexpansion@1.6.0, cats@1.7.0, floating-landmasses@1.0.6, foxtaming@1.2.0, playercorpse@1.7.1, tpnet@1.10.1, wolftaming@1.7.1

There seems to be a non-fatal problem with animalcages mod, the same as it's on native install, so I'm not concerned.

## Reforged 118 Hardmode

bettercrates@1.6.0-rc.1, cairns@1.0.0, compass2@2.0.0, cropsconfig@1.0.0, hqzlights@1.1.1, pantherinae@1.0.3, instruments@1.2.0, meteoricexpansion@1.2.3, moreclasses@1.2.5, nightwatcher@1.4.0, game@1.18.1, alchemy@1.6.9, animalcages@2.1.4, carryon@1.0.0-rc.2, coinage@1.3.0, commonlib@2.0.4, immersivecrafting@1.1.1, sailboat@1.0.0, medievalexpansion@3.9.1, petai@1.7.0, scarecrow@1.2.3, stillnecessaries@1.0.0, stonebakeoven@1.0.0, usefulstuff17@1.1.3, creative@1.18.1, vsquest@0.4.1, survival@1.18.1, vsvillage@0.7.2, xlib@0.7.0-pre.3, em@2.0.0-pre.5, feverstonewilds@1.2.0, playercorpse@1.7.1, xskills@0.7.0-pre.5, bricklayers@2.0.0-pre.4

# Notes

Some other servers I tested still crash the game with both my flatpak install and my native install, so it seems to be a Linux-related problem in general. It won't be addressed here.

**Keep in mind the fix applies for all versions of the game.** 