### PR TITLE
Add support for vintagestoryjoin://

### DIFF
--- a/at.vintagestory.VintageStory-vintagestoryjoin.desktop
+++ b/at.vintagestory.VintageStory-vintagestoryjoin.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Vintage Story (join)
+NoDisplay=true
+Exec=vintagestory -c %u
+Terminal=false
+Type=Application
+StartupNotify=false
+Icon=at.vintagestory.VintageStory
+MimeType=x-scheme-handler/vintagestoryjoin

--- a/at.vintagestory.VintageStory.yaml
+++ b/at.vintagestory.VintageStory.yaml
@@ -32,6 +32,7 @@ modules:
       - install -Dpt /app/share/icons/hicolor/512x512/apps at.vintagestory.VintageStory.png
       - install -Dpt /app/share/metainfo at.vintagestory.VintageStory.metainfo.xml
       - desktop-file-install --dir=/app/share/applications at.vintagestory.VintageStory.desktop
+      - desktop-file-install --dir=/app/share/applications at.vintagestory.VintageStory-vintagestoryjoin.desktop
     sources:
       - type: script
         dest-filename: vintagestory
@@ -39,13 +40,15 @@ modules:
                 # cert-sync is needed to update mono's certificates, or
                 # communication with Vintage Story's auth server may fail
           - /app/bin/mono ${MONO_PATH}/cert-sync.exe --quiet --user /etc/ssl/certs/ca-certificates.crt
-          - exec /app/bin/mono /app/extra/vintagestory/Vintagestory.exe
+          - exec /app/bin/mono /app/extra/vintagestory/Vintagestory.exe "$@"
       - type: script
         dest-filename: mcs
         commands:
           - exec /app/bin/mono $MONO_OPTIONS /app/lib/mono/4.5/mcs.exe "$@"
       - type: file
         path: at.vintagestory.VintageStory.desktop
+      - type: file
+        path: at.vintagestory.VintageStory-vintagestoryjoin.desktop
       - type: file
             # from converting Vintage Story's assets/gameicon.xpm to png
         path: at.vintagestory.VintageStory.png


### PR DESCRIPTION
closes #40 

## vintagestoryjoin

`vintagestoryjoin://` was added as a part of [Christmas Patch (v1.14.3-rc.1)
](https://www.vintagestory.at/blog.html/news/christmas-patch-v1143-rc1-r272/). This allows players to quickly launch the game and connect to a server by clicking a link.

Example:

| URI | command |
| - | - |
| `vintagestoryjoin://127.0.0.1` | `VintageStory.exe -c 127.0.0.1` |