### PR TITLE
Update Freedesktop SDK runtime to 22.08

### DIFF
--- a/at.vintagestory.VintageStory.yaml
+++ b/at.vintagestory.VintageStory.yaml
@@ -1,6 +1,6 @@
 app-id: at.vintagestory.VintageStory
 runtime: org.freedesktop.Platform
-runtime-version: '21.08'
+runtime-version: '22.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.mono6


### PR DESCRIPTION
Long overdue [runtime upgrade](https://discourse.flathub.org/t/freedesktop-sdk-22-08-0-released/2871).

It comes with performance improvements due to underlying Mesa upgrade from version 21 to 23.