### PR TITLE
Install missing fonts

### DIFF
--- a/at.vintagestory.VintageStory.yaml
+++ b/at.vintagestory.VintageStory.yaml
@@ -69,3 +69,11 @@ modules:
         commands:
           - tar -xf vs_archive.tar.gz
           - rm -f vs_archive.tar.gz
+          - fc-cache --force --system-only
+  - name: fontconfig
+    buildsystem: simple
+    build-commands:
+      - install -Dpm644 fontpath.conf /app/etc/fonts/local.conf
+    sources:
+      - type: file
+        path: fontpath.conf

--- a/fontpath.conf
+++ b/fontpath.conf
@@ -1,0 +1,5 @@
+<?xml version="1.0"?>
+<!DOCTYPE fontconfig SYSTEM "fonts.dtd">
+<fontconfig>
+    <dir salt="vintagestory">/app/extra/vintagestory/assets/game/fonts</dir>
+</fontconfig>


### PR DESCRIPTION
This change installs fonts from Visual Story distributable. See before and after screenshots for comparison below.

If you want to see these changes in action by yourself, keep in mind you won't be able to tell the difference if you already have these fonts installed on your system.

Because previously the game archive was downloaded and installed using extra-data, the fonts contained inside were unreachable in build time. I had to change things around. There are a few refactoring changes that allow access to these fonts and are installed along with the game itself.

* The most important change: we're no longer relying on extra-data and apply_extra script to install game files. Now, we extract game files, and move it to a proper `/usr/share/vintagestory` directory, instead of relying on `/usr/extra/vintagestory` like before.
* `mcs` install was moved to the mono module, this should be done from the start.
* icons, desktop files etc. were moved to their own module.
* `size` property was removed from tarball source definition, because it does not belong to `archive` type.

I'd appreciate reviewing and verifying the change carefully. I don't have much experience with flatpak manifests, I hope everything is in order.

# Font comparison

## Main menu

### Before

![Screenshot_20230508_232713](https://user-images.githubusercontent.com/864964/236947934-26d3d44a-f85c-4a67-9bd6-37f785b7d4b1.png)

### After

![Screenshot_20230508_233012](https://user-images.githubusercontent.com/864964/236948060-e7734ef2-dfb5-46be-a294-2287d8088148.png)

## Signs/plaques

### Before

![Screenshot_20230508_232906](https://user-images.githubusercontent.com/864964/236948099-80c6c31a-f72f-4316-8ae2-7503fa830942.png)

### After

![Screenshot_20230508_233106](https://user-images.githubusercontent.com/864964/236948137-9467e5f2-0e46-42f1-a0ff-bfbffb9094d7.png)

## Pause menu

### Before

![Screenshot_20230508_232917](https://user-images.githubusercontent.com/864964/236948172-bc2cb088-b432-43fb-8592-565eecd7cf10.png)

### After

![Screenshot_20230508_233114](https://user-images.githubusercontent.com/864964/236948197-9c88956b-d15d-4444-b232-c39a14f044af.png)


