### PR TITLE
Fix screenshots not being saved

### DIFF
--- a/at.vintagestory.VintageStory.yaml
+++ b/at.vintagestory.VintageStory.yaml
@@ -11,6 +11,7 @@ finish-args:
   - --socket=x11
   - --socket=pulseaudio
   - --device=dri
+  - --filesystem=xdg-pictures/Vintagestory:create
   - --env=MONO_PATH=/app/lib/mono/4.5
 modules:
   - name: mono


### PR DESCRIPTION
This fixes the problem with screenshots (F12) not being saved anywhere.

Originally reported here: https://github.com/anegostudios/VintageStory-Issues/issues/2567

The game uses `XDG_PICTURES_DIR/Vintagestory` for saving screenshots, but this location was not given [sandbox permissions](https://docs.flatpak.org/en/latest/sandbox-permissions-reference.html#filesystem-permissions). This change gives the game access to that directory so the screenshots can be saved.