### PR TITLE
Update Runtime and Add scheme handler

### DIFF
--- a/at.vintagestory.VintageStory-vintagestorymodinstall.desktop
+++ b/at.vintagestory.VintageStory-vintagestorymodinstall.desktop
@@ -1,0 +1,9 @@
+[Desktop Entry]
+Name=Vintage Story (modinstall)
+NoDisplay=true
+Exec=vintagestory -i %u
+Terminal=false
+Type=Application
+StartupNotify=false
+Icon=at.vintagestory.VintageStory
+MimeType=x-scheme-handler/vintagestorymodinstall

--- a/at.vintagestory.VintageStory.metainfo.xml
+++ b/at.vintagestory.VintageStory.metainfo.xml
@@ -26,8 +26,8 @@
         <content_attribute id="social-chat">intense</content_attribute>
     </content_rating>
     <url type="homepage">https://www.vintagestory.at/</url>
-    <url type="faq">https://www.vintagestory.at/features/faq.html/</url>
-    <url type="help">http://wiki.vintagestory.at/</url>
+    <url type="faq">https://www.vintagestory.at/faq.html/</url>
+    <url type="help">https://wiki.vintagestory.at/</url>
     <url type="contact">https://www.vintagestory.at/contact/</url>
     <url type="bugtracker">https://github.com/anegostudios/VintageStory-Issues/issues</url>
     <screenshots>

--- a/at.vintagestory.VintageStory.yaml
+++ b/at.vintagestory.VintageStory.yaml
@@ -1,6 +1,6 @@
 app-id: at.vintagestory.VintageStory
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.dotnet7

--- a/at.vintagestory.VintageStory.yaml
+++ b/at.vintagestory.VintageStory.yaml
@@ -31,6 +31,7 @@ modules:
       - install -Dpt /app/share/metainfo at.vintagestory.VintageStory.metainfo.xml
       - desktop-file-install --dir=/app/share/applications at.vintagestory.VintageStory.desktop
       - desktop-file-install --dir=/app/share/applications at.vintagestory.VintageStory-vintagestoryjoin.desktop
+      - desktop-file-install --dir=/app/share/applications at.vintagestory.VintageStory-vintagestorymodinstall.desktop
     sources:
       - type: script
         dest-filename: vintagestory
@@ -40,6 +41,8 @@ modules:
         path: at.vintagestory.VintageStory.desktop
       - type: file
         path: at.vintagestory.VintageStory-vintagestoryjoin.desktop
+      - type: file
+        path: at.vintagestory.VintageStory-vintagestorymodinstall.desktop
       - type: file
             # from converting Vintage Story's assets/gameicon.xpm to png
         path: at.vintagestory.VintageStory.png


### PR DESCRIPTION
Moves to the Freedesktop 23.08 runtime.

I have been playing singleplayer using the updated runtime for about a week, and haven't noticed any problems.

Also adds a scheme handler for moddb's modinstall scheme.

Fixes: #76 