### PR TITLE
Might be the fix to the build failure

### DIFF
--- a/at.vintagestory.VintageStory.yaml
+++ b/at.vintagestory.VintageStory.yaml
@@ -9,7 +9,7 @@ build-options:
   append-ld-library-path: /usr/lib/sdk/dotnet7/lib
   env:
     PKG_CONFIG_PATH: /app/lib/pkgconfig:/app/share/pkgconfig:/usr/lib/pkgconfig:/usr/share/pkgconfig:/usr/lib/sdk/dotnet7/lib/pkgconfig
-command: /app/bin/vintagestory
+command: vintagestory
 finish-args:
   - --share=network
   - --share=ipc


### PR DESCRIPTION
Comment from the build failure:

"toplevel-command-is-path: Command in manifest is a path /app/bin/vintagestory. Please install the executable to $FLATPAK_DEST/bin and change command to just the name"
