### PR TITLE
Screenshots & Description update

### DIFF
--- a/at.vintagestory.VintageStory.metainfo.xml
+++ b/at.vintagestory.VintageStory.metainfo.xml
@@ -32,24 +32,24 @@
     <url type="bugtracker">https://github.com/anegostudios/VintageStory-Issues/issues</url>
     <screenshots>
         <screenshot type="default">
-            <image>https://content.invisioncic.com/r268468/monthly_2020_11/2020-08-23_13-20-08.jpg.1f51580ecd4e3ef1388e021d95d4ff69.jpg</image>
+            <image>https://media.invisioncic.com/r268468/monthly_2024_12/2022-12-29_21-16-00.jpg.2891475dc036dbf5190cd09cc9812402.jpg</image>
         </screenshot>
         <screenshot>
-            <image>https://content.invisioncic.com/r268468/monthly_2020_11/2020-07-26_23-12-17.jpg.7635d230a1388d36f7a603229003eab3.jpg</image>
+            <image>https://media.invisioncic.com/r268468/monthly_2024_12/2024-12-04_18-26-09.jpg.0440281e3449f9d7c338dbba0c189725.jpg</image>
         </screenshot>
         <screenshot>
-            <image>https://content.invisioncic.com/r268468/monthly_2020_11/2020-10-18_19-30-18.jpg.2958939ed55399c600c339517d95df0e.jpg</image>
+            <image>https://media.invisioncic.com/r268468/monthly_2024_12/2024-12-04_18-20-33.jpg.cd9bddecee542a8792eb0b4af56a7dcf.jpg</image>
         </screenshot>
         <screenshot>
-            <image>https://content.invisioncic.com/r268468/monthly_2020_11/2020-07-26_23-11-40.jpg.c3643a57b4ff423bf806e75933ddef34.jpg</image>
+            <image>https://media.invisioncic.com/r268468/monthly_2024_12/2024-01-16_13-39-14.jpg.dd096cb1fcb2cf73cf864eedc37ec43b.jpg</image>
         </screenshot>
         <screenshot>
-            <image>https://content.invisioncic.com/r268468/monthly_2020_11/2020-07-28_15-15-35.jpg.0040c882a88e78b8129dce862b7b7525.jpg</image>
+            <image>https://media.invisioncic.com/r268468/monthly_2024_12/2023-04-26_16-48-12.jpg.ec120e42626a95976e9cbeb477e55859.jpg</image>
         </screenshot>
     </screenshots>
     <releases>
         <release version="1.20.0" date="2025-01-17">
-            <description></description>
+            <description>Lore Update: The Journey</description>
         </release>
         <release version="1.19.8" date="2024-05-17">
             <description>


### PR DESCRIPTION
This PR should fix the build errors concerning the unavailable screenshots, by replacing the old links with new ones and it adds the new update's name to the description :)